### PR TITLE
UBSAN.filter: update

### DIFF
--- a/UBSAN.filter
+++ b/UBSAN.filter
@@ -31,38 +31,40 @@
 alignment:*
 ## MDEV-35714 [MTR, main.dyncol]
 object-size:Item_dyncol_get::get_date
-## MDEV-36375 [MTR, main.gis]
-enum:get_all_tables
-## MDEV-36451 [MTR, main.blackhole]
-float-cast-overflow:best_access_path
-## MDEV-36453 [MTR, main.mysqltest]
-pointer-overflow:do_block
 ## MDEV-35715 [MTR, main.type_enum]
 float-cast-overflow:Field_bit::store
 float-cast-overflow:Field_set::store
 float-cast-overflow:Field_enum::store
+## MDEV-36346 [MTR, main.select]
+float-cast-overflow:test_if_cheaper_ordering
+## MDEV-35555 [MTR, main.partition_explicit_prune]
+pointer-overflow:sel_trees_must_be_ored
+#--- BELOW ARE FIXED FOR 10.11+, so still affecting 10.6 Enterprise
+
+## MDEV-36451 [MTR, main.blackhole]
+float-cast-overflow:best_access_path
+## MDEV-36453 [MTR, main.mysqltest]
+pointer-overflow:do_block
 ## MDEV-35721 [MTR, main.update_innodb, 10.11+ fixed]
 float-cast-overflow:Index_statistics::set_avg_frequency
 ## MDEV-36344 [MTR, main.index_intersect_innodb]
 pointer-overflow:Forward_lifo_buffer::have_space_for
-## MDEV-36346 [MTR, main.select]
-float-cast-overflow:test_if_cheaper_ordering
 ## MDEV-35595
 enum:Gis_polygon::init_from_wkb
 enum:wkb_get_uint
 enum:Gis_line_string::init_from_wkb
-## MDEV-35589/MDEV-36542/MDEV-35590 [MTR, 10.11+ fixed]
+## MDEV-35590 [MTR, 10.11+ fixed]
 bool:extract_date_time
-## MDEV-35556
-pointer-overflow:myrocks::Rdb_key_def::setup
-## MDEV-35555
-pointer-overflow:sel_trees_must_be_ored
 ## MDEV-35548
 bounds:json_get_path_start
 ## MDEV-35545 [MTR, main.gis]
 pointer-overflow:Gis_geometry_collection::init_from_opresult
 
 # ----- Fixed bugs | Note the '## Fixed ' prefixes are required for bugs_check_status_jira.sh
+## Fixed ## MDEV-36375 [MTR, main.gis]
+#enum:get_all_tables
+## Fixed ## MDEV-35556
+#pointer-overflow:myrocks::Rdb_key_def::setup
 ## Fixed ## MDEV-37626 [MTR, innodb.innodb-table-online innodb.innodb-index-online]
 #pointer-overflow:row_log_apply_ops
 #pointer-overflow:row_log_table_apply_ops


### PR DESCRIPTION
Puts those with 10.11+ only fixes below a line that Buildbot can strip out to prevent regressions.

Closes a few.

For merge once the 2026Q3 completes its 13.0.2 TODO-6175 and 13.1.1 TODO-6177